### PR TITLE
Consecutive declarations on a line must be separated by ';'

### DIFF
--- a/Sources/ResourceKitCore/Storyboard/ViewController/ViewControllerOutput.swift
+++ b/Sources/ResourceKitCore/Storyboard/ViewController/ViewControllerOutput.swift
@@ -90,7 +90,7 @@ fileprivate extension ViewControllerOutputImpl {
             .flatMap {
                 "\(Const.tab2)public static let \($0.lowerFirst): String = \"\($0)\""
             }
-            .joined()
+            .joined(separator: Const.newLine)
         let end = "\(Const.tab1)}"
         return [begin, body, end].joined(separator: Const.newLine)
     }


### PR DESCRIPTION
<img width="1249" alt="2018-04-23 20 53 50" src="https://user-images.githubusercontent.com/9856514/39124992-73b4cff8-4738-11e8-96a1-0e5db2eb5de2.png">

Add line break to property of `Segue` struct of UIViewController.